### PR TITLE
Parse rules on successful request

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 venv/bin/python:
-	virtualenv venv --python=`which python`
+	virtualenv venv
 	venv/bin/pip install -r requirements.txt
 
 .PHONY: install
-install:
+install: venv/bin/python
 	venv/bin/python setup.py install
 
 .PHONY: check

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,6 @@ pycodestyle==2.3.1
 pyflakes==1.6.0
 python-dateutil==2.7.3
 pytz==2018.5
-requests==2.19.1
+requests==2.21.0
 six==1.11.0
 urllib3==1.23

--- a/rulesengine_client/response.py
+++ b/rulesengine_client/response.py
@@ -1,4 +1,5 @@
 from .exceptions import MalformedResponseException
+from .models import RuleCollection
 
 
 class Response(object):
@@ -14,3 +15,15 @@ class Response(object):
         self.message = self.json['message']
         if 'result' in self.json:
             self.result = self.json['result']
+        self.rules = None
+        if self.status == 'success':
+            self._parse_result()
+
+    def _parse_result(self):
+        if isinstance(self.result, list):
+            self.rules = RuleCollection.from_response(self.result)
+        elif isinstance(self.result, dict):
+            self.rules = RuleCollection.from_response([self.result])
+        else:
+            raise MalformedResponseException(
+                'received unexpected result', self.result)

--- a/rulesengine_client/tests/test_client.py
+++ b/rulesengine_client/tests/test_client.py
@@ -20,7 +20,7 @@ class ClientTestCase(unittest.TestCase):
     def test_get_rules(self, mock_request):
         mock_request.return_value = StubResponse(
             200,
-            '{"status": "success", "message": "ok", "result": [1, 2, 3]}')
+            '{"status": "success", "message": "ok", "result": []}')
         c = Client('http://localhost')
         result = c.get_rules()
         self.assertEqual(result.status_code, 200)
@@ -30,7 +30,7 @@ class ClientTestCase(unittest.TestCase):
     def test_create_rule(self, mock_request):
         mock_request.return_value = StubResponse(
             200,
-            '{"status": "success", "message": "ok", "result": [1, 2, 3]}')
+            '{"status": "success", "message": "ok", "result": []}')
         c = Client('http://localhost')
         result = c.create_rule({})
         self.assertEqual(result.status_code, 200)
@@ -40,7 +40,7 @@ class ClientTestCase(unittest.TestCase):
     def test_get_rule(self, mock_request):
         mock_request.return_value = StubResponse(
             200,
-            '{"status": "success", "message": "ok", "result": [1, 2, 3]}')
+            '{"status": "success", "message": "ok", "result": []}')
         c = Client('http://localhost')
         result = c.get_rule(1)
         self.assertEqual(result.status_code, 200)
@@ -50,7 +50,7 @@ class ClientTestCase(unittest.TestCase):
     def test_update_rule(self, mock_request):
         mock_request.return_value = StubResponse(
             200,
-            '{"status": "success", "message": "ok", "result": [1, 2, 3]}')
+            '{"status": "success", "message": "ok", "result": []}')
         c = Client('http://localhost')
         result = c.update_rule(1, {})
         self.assertEqual(result.status_code, 200)
@@ -61,7 +61,7 @@ class ClientTestCase(unittest.TestCase):
     def test_delete_rule(self, mock_request):
         mock_request.return_value = StubResponse(
             200,
-            '{"status": "success", "message": "ok", "result": [1, 2, 3]}')
+            '{"status": "success", "message": "ok", "result": []}')
         c = Client('http://localhost')
         result = c.delete_rule(1)
         self.assertEqual(result.status_code, 200)
@@ -71,7 +71,7 @@ class ClientTestCase(unittest.TestCase):
     def test_tree_for_surt(self, mock_request):
         mock_request.return_value = StubResponse(
             200,
-            '{"status": "success", "message": "ok", "result": [1, 2, 3]}')
+            '{"status": "success", "message": "ok", "result": []}')
         c = Client('http://localhost')
         result = c.tree_for_surt('http://(org,archive,)')
         self.assertEqual(result.status_code, 200)
@@ -82,7 +82,7 @@ class ClientTestCase(unittest.TestCase):
     def test_rules_for_request(self, mock_request):
         mock_request.return_value = StubResponse(
             200,
-            '{"status": "success", "message": "ok", "result": [1, 2, 3]}')
+            '{"status": "success", "message": "ok", "result": []}')
         c = Client('http://localhost')
         result = c.rules_for_request('http://(org,archive,)', 'today')
         self.assertEqual(result.status_code, 200)

--- a/rulesengine_client/tests/test_response.py
+++ b/rulesengine_client/tests/test_response.py
@@ -20,11 +20,51 @@ class ResponseTestCase(unittest.TestCase):
     def test_success(self):
         response = Response(StubResponse(
             200,
-            '{"status": "success", "message": "ok", "result": [1, 2, 3]}'))
+            '{"status": "success", "message": "ok", "result": []}'))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.status, 'success')
         self.assertEqual(response.message, 'ok')
-        self.assertEqual(response.result, [1, 2, 3])
+        self.assertEqual(response.result, [])
+
+    def test_parse_result_rule(self):
+        response = Response(StubResponse(
+            200,
+            '''{"status": "success", "message": "ok", "result": {
+                "surt": "com,",
+                "policy": "block"
+            }}'''))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status, 'success')
+        self.assertEqual(response.message, 'ok')
+        self.assertEqual(response.rules.rules[0].surt, 'com,')
+        self.assertEqual(response.rules.rules[0].policy, 'block')
+        self.assertEqual(len(response.rules.rules), 1)
+
+    def test_parse_result_rule_collection(self):
+        response = Response(StubResponse(
+            200,
+            '''{"status": "success", "message": "ok", "result": [{
+                "surt": "com,",
+                "policy": "block"
+            }]}'''))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status, 'success')
+        self.assertEqual(response.message, 'ok')
+        self.assertEqual(response.rules.rules[0].surt, 'com,')
+        self.assertEqual(response.rules.rules[0].policy, 'block')
+        self.assertEqual(len(response.rules.rules), 1)
+
+    def test_parse_result_malformed_response(self):
+        with self.assertRaises(MalformedResponseException):
+            Response(StubResponse(
+                200,
+                '''{"status": "success", "message": "ok",
+                "result": "bad-wolf"}'''))
+        with self.assertRaises(MalformedResponseException):
+            Response(StubResponse(
+                200,
+                '''{"status": "success", "message": "ok",
+                "result": {"bad-wolf": "oh no"}'''))
 
     def test_malformed_response(self):
         with self.assertRaises(MalformedResponseException):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 setup(
     name='rulesengine_client',
     description='Client for interacting with the Playback Rules Engine',
-    version='0.1.1',
+    version='0.2.0',
     install_requires=[
         'python-dateutil',
         'ipaddr',


### PR DESCRIPTION
When a request succeeds, it automatically parses the rules into an object on the response, which serves the added benefit of further validation of the response.